### PR TITLE
Update DefaultEngine.ini

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -95,3 +95,6 @@ ReceiveFrom=8060
 [/Script/DisplayClusterEditor.DisplayClusterEditorSettings]
 bEnabled=True
 
+[/Script/LevelSequence.LevelSequence]
+DefaultCompletionMode=KeepState
+


### PR DESCRIPTION
Fix project default for level sequence completion mode to "Keep State" to fix (hopefully) camera jumping issue.